### PR TITLE
Fix deploy github page workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload all content under the web/ directory
+          path: "web/"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
Currently the webpage can be shown by visiting <https://verisimilitude11.github.io/DNAnalyzer/web/>.
This PR should make it available without the `web/` path.

Closes #220.