### PR TITLE
Deepsource Wrong argument order in test assertions fix

### DIFF
--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -64,7 +64,7 @@ public class CmdArgs implements Runnable {
      */
     @Override
     public void run() {
-        if (startGUI) {
+        if (Boolean.TRUE == startGUI) {
             String[] args = new String[0];
             DNAnalyzerGUI.launchIt(args);
         } else {

--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -64,7 +64,7 @@ public class CmdArgs implements Runnable {
      */
     @Override
     public void run() {
-        if (startGUI == true) {
+        if (startGUI) {
             String[] args = new String[0];
             DNAnalyzerGUI.launchIt(args);
         } else {

--- a/src/test/java/DNAnalyzer/CodonDataUtilsTest.java
+++ b/src/test/java/DNAnalyzer/CodonDataUtilsTest.java
@@ -33,7 +33,7 @@ public class CodonDataUtilsTest {
     public void testIsoleucine_expectCorrect(final String acid) {
         final var expected = List.of("ATT", "ATC", "ATA");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -42,7 +42,7 @@ public class CodonDataUtilsTest {
     public void testLeucine_expectCorrect(final String acid) {
         final var expected = List.of("CTT", "CTC", "CTA", "CTG", "TTA", "TTG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -51,7 +51,7 @@ public class CodonDataUtilsTest {
     public void testValine_expectCorrect(final String acid) {
         final var expected = List.of("GTT", "GTC", "GTA", "GTG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -60,7 +60,7 @@ public class CodonDataUtilsTest {
     public void testPhenylalanine_expectCorrect(final String acid) {
         final var expected = List.of("TTT", "TTC");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -76,7 +76,7 @@ public class CodonDataUtilsTest {
     public void getCysteineTest(final String acid) {
         final var expected = List.of("TGT", "TGC");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -85,7 +85,7 @@ public class CodonDataUtilsTest {
     public void getAlanineTest(final String acid) {
         final var expected = List.of("GCT", "GCC", "GCA", "GCG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -94,7 +94,7 @@ public class CodonDataUtilsTest {
     public void getGlycineTest(final String acid) {
         final var expected = List.of("GGT", "GGC", "GGA", "GGG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -103,7 +103,7 @@ public class CodonDataUtilsTest {
     public void getProlineTest(final String acid) {
         final var expected = List.of("CCT", "CCC", "CCA", "CCG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -112,7 +112,7 @@ public class CodonDataUtilsTest {
     public void getThreonineTest(final String acid) {
         final var expected = List.of("ACT", "ACC", "ACA", "ACG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -121,7 +121,7 @@ public class CodonDataUtilsTest {
     public void getSerineTest(final String acid) {
         final var expected = List.of("TCT", "TCC", "TCA", "TCG", "AGT", "AGC");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -130,7 +130,7 @@ public class CodonDataUtilsTest {
     public void getTyrosineTest(final String acid) {
         final var expected = List.of("TAT", "TAC");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -139,7 +139,7 @@ public class CodonDataUtilsTest {
     public void getTryptophanTest(final String acid) {
         final var expected = List.of("TGG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -148,7 +148,7 @@ public class CodonDataUtilsTest {
     public void getGlutamineTest(final String acid) {
         final var expected = List.of("CAA", "CAG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -157,7 +157,7 @@ public class CodonDataUtilsTest {
     public void getAsparagineTest(final String acid) {
         final var expected = List.of("AAT", "AAC");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());;
         assertTrue(actual.containsAll(expected));
     }
 
@@ -166,7 +166,7 @@ public class CodonDataUtilsTest {
     public void getHistidineTest(final String acid) {
         final var expected = List.of("CAT", "CAC");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -175,7 +175,7 @@ public class CodonDataUtilsTest {
     public void getGlutamicAcidTest(final String acid) {
         final var expected = List.of("GAA", "GAG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -184,7 +184,7 @@ public class CodonDataUtilsTest {
     public void getAsparicAcidTest(final String acid) {
         final var expected = List.of("GAT", "GAC");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -193,7 +193,7 @@ public class CodonDataUtilsTest {
     public void getLysineAcidTest(final String acid) {
         final var expected = List.of("AAA", "AAG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 
@@ -202,7 +202,7 @@ public class CodonDataUtilsTest {
     public void getArginineAcidTest(final String acid) {
         final var expected = List.of("CGT", "CGC", "CGA", "CGG", "AGA", "AGG");
         final var actual = CodonDataUtils.getAminoAcid(acid);
-        assertEquals(expected.size(), actual.size());
+        assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
     }
 }


### PR DESCRIPTION
JUnit assertion methods expect the expected value to be the first argument

Signed-off-by: LimesKey <85136735+LimesKey@users.noreply.github.com>

Closes #342.